### PR TITLE
Add twist_mux node

### DIFF
--- a/ros_ws/src/common/constants.h
+++ b/ros_ws/src/common/constants.h
@@ -48,7 +48,7 @@ const std::string AUTO_TOPIC = "auto_twist";
 /**
  * @brief The topic containing twist messages to be sent to the motor controller
  */
-const std::string CMD_VEL_TOPIC = "cmd_vel";
+const std::string CONTROL_TOPIC = "cmd_vel";
 
 //Node name constants
 /**

--- a/ros_ws/src/common/constants.h
+++ b/ros_ws/src/common/constants.h
@@ -15,6 +15,22 @@ const int Y_AXIS_L_STICK = 1;
  * @brief The index of the x axis on the right stick of the controller
  */
 const int X_AXIS_R_STICK = 2;
+/**
+ * @brief The index of the A button on the controller
+ */
+const int A_BUTTON = 0;
+/**
+ * @brief The index of the B button on the controller
+ */
+const int B_BUTTON = 1;
+/**
+ * @brief The index of the X button on the controller
+ */
+const int X_BUTTON = 2;
+/**
+ * @brief The index of the Y button on the controller
+ */
+const int Y_BUTTON = 3;
 
 //Topic name constants
 /**
@@ -22,15 +38,27 @@ const int X_AXIS_R_STICK = 2;
  */
 const std::string JOY_TOPIC = "joy";
 /**
- * @brief The topic that twist messages will be published on
+ * @brief The topic that teleop twist messages will be published on
  */
 const std::string TELEOP_TOPIC = "teleop_twist";
+/**
+ * @brief The topic that autonomous twist messages will be published on
+ */
+const std::string AUTO_TOPIC = "auto_twist";
+/**
+ * @brief The topic containing twist messages to be sent to the motor controller
+ */
+const std::string CMD_VEL_TOPIC = "cmd_vel";
 
 //Node name constants
 /**
  * @brief The node name for the teleop node
  */
 const std::string TELEOP_NODE = "teleop_control";
+/**
+ * @brief The node name for the teleop_mux node
+ */
+const std::string TELEOP_MUX_NODE = "teleop_mux_node";
 
 //Loop rate
 const int LOOP_RATE = 30;

--- a/ros_ws/src/control/CMakeLists.txt
+++ b/ros_ws/src/control/CMakeLists.txt
@@ -27,8 +27,14 @@ include_directories(
     ../common/
 )
 
-add_executable(control_node src/remote_control_node.cpp src/remote_control.cpp)
-add_dependencies(control_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-target_link_libraries(control_node
+add_executable(remote_control_node src/remote_control_node.cpp src/remote_control.cpp)
+add_dependencies(remote_control_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+target_link_libraries(remote_control_node 
+    ${catkin_LIBRARIES}
+)
+
+add_executable(teleop_mux_node src/control/twist_mux_node.cpp src/control/twist_mux.cpp)
+add_dependencies(teleop_mux_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+target_link_libraries(teleop_mux_node 
     ${catkin_LIBRARIES}
 )

--- a/ros_ws/src/control/include/control/twist_mux.h
+++ b/ros_ws/src/control/include/control/twist_mux.h
@@ -57,12 +57,7 @@ private:
     /**
      * @brief The subscriber which receives twist messages from the teleop node
      */
-    ros::Subscriber teleop_sub;
-
-    /**
-     * @brief The subscriber which receives twist messages from the autonomous node
-     */
-    ros::Subscriber autonomous_sub;
+    ros::Subscriber twist_sub;
 
     /**
      * @brief The twist message publisher

--- a/ros_ws/src/control/include/control/twist_mux.h
+++ b/ros_ws/src/control/include/control/twist_mux.h
@@ -1,0 +1,104 @@
+/**
+ * @file twist_mux.h
+ * @class TwistMux
+ * @brief A simple class which accepts multiple twist messages and outputs only one
+ *
+ * This class should act as a way to select which twist message is being sent to the robots motor controllers.  The
+ * message can come from multiple places including the teleop node, the estop node (built in to this class), or the
+ * autonomous node.  The twist mux will use joy messages to decide which twist message should be used at any given
+ * time.
+ */
+
+#ifndef CONTROL_INCLUDE_CONTROL_TWIST_MUX_H_
+#define CONTROL_INCLUDE_CONTROL_TWIST_MUX_H_
+
+#include <ros/ros.h>
+#include <sensor_msgs/Joy.h>
+#include <geometry_msgs/Twist.h>
+#include "constants.h"
+
+class TwistMux
+{
+private:
+    /**
+     * @brief An enumerator to describe the mode the robot is currently in
+     */
+    enum Mode
+    {
+        standby,        //!< The robot is not moving, the same as a software e-stop
+        teleop,         //!< The robot is currently being controlled by remote control
+        autonomous      //!< The robot is driving itself
+    };
+
+    /**
+     * @brief The mode which the robot is currently in
+     */
+    Mode current_mode;
+
+    /**
+     * @brief The twist message which is sent to the motor controllers of the robot
+     */
+    geometry_msgs::Twist cmd_vel;
+
+    /**
+     * @brief The joy message subscriber
+     *
+     * This ros subscriber will be responsible for subscribing to the joy message published by the controller method
+     * that is being used.
+     */
+    ros::Subscriber joy_sub;
+
+    /**
+     * @brief The subscriber which receives twist messages from the teleop node
+     */
+    ros::Subscriber teleop_sub;
+
+    /**
+     * @brief The subscriber which receives twist messages from the autonomous node
+     */
+    ros::Subscriber autonomous_sub;
+
+    /**
+     * @brief The twist message publisher
+     *
+     * This ros publisher is responsible for the publishing of the twist message which will control the robot.
+     */
+    ros::Publisher twist_pub;
+
+    /**
+     * @brief The ros node handle
+     */
+    ros::NodeHandle nh;
+
+    /**
+     * @brief The callback function for joy messages
+     *
+     * This function takes joy messages and reads information from the buttons to decide what mode it should currently
+     * be running in.
+     *
+     * @param msg The message which is received from the joy publisher
+     */
+    void joyCallback(const sensor_msgs::Joy::ConstPtr& msg);
+
+    /**
+     * @brief The callback function for twist messages
+     *
+     * This function takes in twist messages and parses the information to the member variable cmd_vel which is
+     * published to the motor controllers.
+     *
+     * @param msg The message which is received from the twist publisher
+     */
+    void twistCallback(const geometry_msgs::Twist::ConstPtr& msg);
+
+    /**
+     * @brief Sets all the fields in cmd_vel to 0 to ensure the robot is not moving
+     */
+    void stopRobot();
+
+public:
+    TwistMux();
+
+    void update();
+};
+
+#endif /* CONTROL_INCLUDE_CONTROL_TWIST_MUX_H_ */

--- a/ros_ws/src/control/include/control/twist_mux.h
+++ b/ros_ws/src/control/include/control/twist_mux.h
@@ -17,9 +17,11 @@
 #include <geometry_msgs/Twist.h>
 #include "constants.h"
 
-class TwistMux
+/**
+ * @brief Control namespace
+ */
+namespace Control
 {
-private:
     /**
      * @brief An enumerator to describe the mode the robot is currently in
      */
@@ -29,11 +31,15 @@ private:
         teleop,         //!< The robot is currently being controlled by remote control
         autonomous      //!< The robot is driving itself
     };
+}
 
+class TwistMux
+{
+private:
     /**
      * @brief The mode which the robot is currently in
      */
-    Mode current_mode;
+    Control::Mode current_mode;
 
     /**
      * @brief The twist message which is sent to the motor controllers of the robot

--- a/ros_ws/src/control/src/control/twist_mux.cpp
+++ b/ros_ws/src/control/src/control/twist_mux.cpp
@@ -17,7 +17,7 @@ TwistMux::TwistMux()
     teleop_sub = nh.subscribe<geometry_msgs::Twist>(TELEOP_TOPIC, 1, &TwistMux::twistCallback, this);
     autonomous_sub = nh.subscribe<geometry_msgs::Twist>(AUTO_TOPIC, 1, &TwistMux::twistCallback, this);
 
-    twist_pub = nh.advertise<geometry_msgs::Twist>(CMD_VEL_TOPIC, 1);
+    twist_pub = nh.advertise<geometry_msgs::Twist>(CONTROL_TOPIC, 1);
 }
 
 void TwistMux::update()

--- a/ros_ws/src/control/src/control/twist_mux.cpp
+++ b/ros_ws/src/control/src/control/twist_mux.cpp
@@ -9,7 +9,7 @@
 TwistMux::TwistMux()
 {
     //Ensure that the robot starts in a safe standby mode
-    current_mode = standby;
+    current_mode = Control::standby;
     stopRobot();
 
     //Setup publishers and subscribers
@@ -28,30 +28,20 @@ void TwistMux::update()
 void TwistMux::joyCallback(const sensor_msgs::Joy::ConstPtr& msg)
 {
     if(msg->buttons[B_BUTTON] == 1)
-        current_mode = standby;
+        current_mode = Control::standby;
     else if(msg->buttons[A_BUTTON] == 1)
-        current_mode = teleop;
+        current_mode = Control::teleop;
     else if(msg->buttons[Y_BUTTON] == 1)
-        current_mode = autonomous;
+        current_mode = Control::autonomous;
 }
 
 void TwistMux::twistCallback(const geometry_msgs::Twist::ConstPtr& msg)
 {
-    cmd_vel.linear.x = msg->linear.x;
-    cmd_vel.linear.y = msg->linear.y;
-    cmd_vel.linear.z = msg->linear.z;
-    cmd_vel.angular.x = msg->angular.x;
-    cmd_vel.angular.y = msg->angular.y;
-    cmd_vel.angular.z = msg->angular.z;
+    cmd_vel = *msg;
 }
 
 void TwistMux::stopRobot()
 {
-    cmd_vel.linear.x = 0;
-    cmd_vel.linear.y = 0;
-    cmd_vel.linear.z = 0;
-    cmd_vel.angular.x = 0;
-    cmd_vel.angular.y = 0;
-    cmd_vel.angular.z = 0;
+    cmd_vel = geometry_msgs::Twist();
 }
 

--- a/ros_ws/src/control/src/control/twist_mux.cpp
+++ b/ros_ws/src/control/src/control/twist_mux.cpp
@@ -14,25 +14,35 @@ TwistMux::TwistMux()
 
     //Setup publishers and subscribers
     joy_sub = nh.subscribe<sensor_msgs::Joy>(JOY_TOPIC, 1, &TwistMux::joyCallback, this);
-    teleop_sub = nh.subscribe<geometry_msgs::Twist>(TELEOP_TOPIC, 1, &TwistMux::twistCallback, this);
-    autonomous_sub = nh.subscribe<geometry_msgs::Twist>(AUTO_TOPIC, 1, &TwistMux::twistCallback, this);
 
     twist_pub = nh.advertise<geometry_msgs::Twist>(CONTROL_TOPIC, 1);
 }
 
 void TwistMux::update()
 {
-
+    twist_pub.publish(cmd_vel);
 }
 
 void TwistMux::joyCallback(const sensor_msgs::Joy::ConstPtr& msg)
 {
     if(msg->buttons[B_BUTTON] == 1)
+    {
         current_mode = Control::standby;
+        stopRobot();
+        twist_sub = nh.subscribe<geometry_msgs::Twist>(AUTO_TOPIC, 1, &TwistMux::twistCallback, this);
+    }
     else if(msg->buttons[A_BUTTON] == 1)
+    {
         current_mode = Control::teleop;
+        stopRobot();
+        twist_sub = nh.subscribe<geometry_msgs::Twist>(TELEOP_TOPIC, 1, &TwistMux::twistCallback, this);
+    }
     else if(msg->buttons[Y_BUTTON] == 1)
+    {
         current_mode = Control::autonomous;
+        stopRobot();
+        twist_sub.shutdown();
+    }
 }
 
 void TwistMux::twistCallback(const geometry_msgs::Twist::ConstPtr& msg)

--- a/ros_ws/src/control/src/control/twist_mux.cpp
+++ b/ros_ws/src/control/src/control/twist_mux.cpp
@@ -1,0 +1,57 @@
+/**
+ * @file twist_mux.cpp
+ * @class TwistMux
+ * @brief The implementation file for the TwistMux class
+ */
+
+#include <twist_mux.h>
+
+TwistMux::TwistMux()
+{
+    //Ensure that the robot starts in a safe standby mode
+    current_mode = standby;
+    stopRobot();
+
+    //Setup publishers and subscribers
+    joy_sub = nh.subscribe<sensor_msgs::Joy>(JOY_TOPIC, 1, &TwistMux::joyCallback, this);
+    teleop_sub = nh.subscribe<geometry_msgs::Twist>(TELEOP_TOPIC, 1, &TwistMux::twistCallback, this);
+    autonomous_sub = nh.subscribe<geometry_msgs::Twist>(AUTO_TOPIC, 1, &TwistMux::twistCallback, this);
+
+    twist_pub = nh.advertise<geometry_msgs::Twist>(CMD_VEL_TOPIC, 1);
+}
+
+void TwistMux::update()
+{
+
+}
+
+void TwistMux::joyCallback(const sensor_msgs::Joy::ConstPtr& msg)
+{
+    if(msg->buttons[B_BUTTON] == 1)
+        current_mode = standby;
+    else if(msg->buttons[A_BUTTON] == 1)
+        current_mode = teleop;
+    else if(msg->buttons[Y_BUTTON] == 1)
+        current_mode = autonomous;
+}
+
+void TwistMux::twistCallback(const geometry_msgs::Twist::ConstPtr& msg)
+{
+    cmd_vel.linear.x = msg->linear.x;
+    cmd_vel.linear.y = msg->linear.y;
+    cmd_vel.linear.z = msg->linear.z;
+    cmd_vel.angular.x = msg->angular.x;
+    cmd_vel.angular.y = msg->angular.y;
+    cmd_vel.angular.z = msg->angular.z;
+}
+
+void TwistMux::stopRobot()
+{
+    cmd_vel.linear.x = 0;
+    cmd_vel.linear.y = 0;
+    cmd_vel.linear.z = 0;
+    cmd_vel.angular.x = 0;
+    cmd_vel.angular.y = 0;
+    cmd_vel.angular.z = 0;
+}
+

--- a/ros_ws/src/control/src/control/twist_mux_node.cpp
+++ b/ros_ws/src/control/src/control/twist_mux_node.cpp
@@ -1,0 +1,24 @@
+/**
+ * @file teleop_mux_node.cpp
+ * @brief The main file for the teleop_mux node
+ */
+
+#include <ros/ros.h>
+#include "twist_mux.h"
+#include "constants.h"
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, TELEOP_MUX_NODE);
+
+    TwistMux tw;
+
+    ros::Rate loop_rate(LOOP_RATE);
+
+    while(ros::ok())
+    {
+        tw.update();
+        ros::spinOnce();
+        loop_rate.sleep();
+    }
+}


### PR DESCRIPTION
The twist_mux node is a node which takes in multiple twist messages and
publishes only a single twist message to the motor controller on the
"cmd_vel" topic.  The node currently uses the buttons defined in the
constants.h file.

Closes #3
