### PR TITLE
Create motor_controller_node

### DIFF
--- a/ros_ws/src/common/constants.h
+++ b/ros_ws/src/common/constants.h
@@ -49,6 +49,14 @@ const std::string AUTO_TOPIC = "auto_twist";
  * @brief The topic containing twist messages to be sent to the motor controller
  */
 const std::string CONTROL_TOPIC = "cmd_vel";
+/**
+ * @brief The topic that the right wheel angular velocity will be published on
+ */
+const std::string RIGHT_VEL_TOPIC = "right_vel";
+/**
+ * @brief The topic that the left wheel angular velocity will be published on
+ */
+const std::string LEFT_VEL_TOPIC = "left_vel";
 
 //Node name constants
 /**
@@ -59,11 +67,26 @@ const std::string TELEOP_NODE = "teleop_control";
  * @brief The node name for the teleop_mux node
  */
 const std::string TELEOP_MUX_NODE = "teleop_mux_node";
+/**
+ * @brief The node name for the motor_controller node
+ */
+const std::string MOTOR_CONTROLLER_NODE = "motor_controller_node";
 
 //Loop rate
 /**
  * @brief The rate that the loops will run at in Hz
  */
 const int LOOP_RATE = 30;
+
+//Robot Parameters
+/**
+ * @brief The robots diameter from right wheel to left wheel
+ */
+const double ROBOT_BASE = 0.7;
+/**
+ * @brief The radius of the robot's wheels
+ */
+const double WHEEL_RAD = 0.19;
+
 
 #endif /* COMMON_CONSTANTS_H_ */

--- a/ros_ws/src/control/CMakeLists.txt
+++ b/ros_ws/src/control/CMakeLists.txt
@@ -38,3 +38,9 @@ add_dependencies(teleop_mux_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EX
 target_link_libraries(teleop_mux_node 
     ${catkin_LIBRARIES}
 )
+
+add_executable(motor_controller_node src/control/motor_controller_node.cpp src/control/motor_controller.cpp)
+add_dependencies(motor_controller_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+target_link_libraries(motor_controller_node
+    ${catkin_LIBRARIES}
+)

--- a/ros_ws/src/control/include/control/motor_controller.h
+++ b/ros_ws/src/control/include/control/motor_controller.h
@@ -55,6 +55,22 @@ private:
      */
     void twistCallback(const geometry_msgs::Twist::ConstPtr& msg);
 
+    /**
+     * @brief Calculates the right wheel angular velocity based on a differential drive model
+     * @param lin_vel The robot's linear velocity
+     * @param ang_vel The robot's angular velocity
+     * @return The right wheel's angular velocity
+     */
+    double getRightVel(const double lin_vel, const double ang_vel);
+
+    /**
+     * @brief Calculates the left wheel angular velocity based on a differential drive model
+     * @param lin_vel The robot's linear velocity
+     * @param ang_vel The robot's angular velocity
+     * @return The left wheel's angular velocity
+     */
+    double getLeftVel(const double lin_vel, const double ang_vel);
+
 public:
     /**
      * @brief The MotorController default constructor

--- a/ros_ws/src/control/include/control/motor_controller.h
+++ b/ros_ws/src/control/include/control/motor_controller.h
@@ -1,0 +1,73 @@
+/**
+ * @file motor_controller.h
+ * @class MotorController
+ * @brief The class which converts twist messages to angular velocities for the robot's wheels
+ */
+
+#ifndef CONTROL_INCLUDE_CONTROL_MOTOR_CONTROLLER_H_
+#define CONTROL_INCLUDE_CONTROL_MOTOR_CONTROLLER_H_
+
+#include <ros/ros.h>
+#include <geometry_msgs/Twist.h>
+#include <std_msgs/Float64.h>
+#include "constants.h"
+
+class MotorController
+{
+private:
+    /**
+     * @brief The right velocity to be published
+     */
+    std_msgs::Float64 right_vel;
+
+    /**
+     * @brief The left velocity to be published
+     */
+    std_msgs::Float64 left_vel;
+
+    /**
+     * @brief The twist message subscriber
+     */
+    ros::Subscriber twist_sub;
+
+    /**
+     * @brief The right wheel velocity publisher
+     */
+    ros::Publisher right_vel_pub;
+
+    /**
+     * @brief The left wheel velocity publisher
+     */
+    ros::Publisher left_vel_pub;
+
+    /**
+     * @brief The ros node handle
+     */
+    ros::NodeHandle nh;
+
+    /**
+     * @brief The callback function for twist messages
+     *
+     * This function accepts twist messages and converts them into an angular velocity in the form of a Float64 which is
+     * sent to motor controller board
+     *
+     * @param msg The message which is received from the twist publisher
+     */
+    void twistCallback(const geometry_msgs::Twist::ConstPtr& msg);
+
+public:
+    /**
+     * @brief The MotorController default constructor
+     *
+     * The default constructor sets up the class to subscribe to the twist topic CONTROL_TOPIC and publish to the float
+     * topics LEFT_VEL_TOPIC and RIGHT_VEL_TOPIC which are defined in the constants.h file.
+     */
+    MotorController();
+
+    /**
+     * @brief Publish updates to the motors
+     */
+    void update();
+};
+
+#endif /* CONTROL_INCLUDE_CONTROL_MOTOR_CONTROLLER_H_ */

--- a/ros_ws/src/control/src/control/motor_controller.cpp
+++ b/ros_ws/src/control/src/control/motor_controller.cpp
@@ -15,8 +15,18 @@ MotorController::MotorController()
 
 void MotorController::twistCallback(const geometry_msgs::Twist::ConstPtr& msg)
 {
-    right_vel.data = (2 * msg->linear.x + msg->angular.z * ROBOT_BASE) / (2 * WHEEL_RAD);
-    left_vel.data = (2 * msg->linear.x + msg->angular.z * ROBOT_BASE) / (2 * WHEEL_RAD);
+    right_vel.data = getRightVel(msg->linear.x, msg->angular.z);
+    left_vel.data = getLeftVel(msg->linear.x, msg->angular.z);
+}
+
+double MotorController::getRightVel(const double lin_vel, const double ang_vel)
+{
+    return (2 * lin_vel + ang_vel * ROBOT_BASE) / (2 * WHEEL_RAD);
+}
+
+double MotorController::getLeftVel(const double lin_vel, const double ang_vel)
+{
+    return (2 * lin_vel - ang_vel * ROBOT_BASE) / (2 * WHEEL_RAD);
 }
 
 void MotorController::update()

--- a/ros_ws/src/control/src/control/motor_controller.cpp
+++ b/ros_ws/src/control/src/control/motor_controller.cpp
@@ -1,0 +1,26 @@
+/**
+ * @file motor_controller.cpp
+ * @brief The implementation file for the MotorController class
+ */
+
+#include <motor_controller.h>
+
+MotorController::MotorController()
+{
+    //Initialize publishers and subscribers
+    twist_sub = nh.subscribe<geometry_msgs::Twist>(CONTROL_TOPIC, 1, &MotorController::twistCallback, this);
+    right_vel_pub = nh.advertise<std_msgs::Float64>(RIGHT_VEL_TOPIC, 1);
+    left_vel_pub = nh.advertise<std_msgs::Float64>(LEFT_VEL_TOPIC, 1);
+}
+
+void MotorController::twistCallback(const geometry_msgs::Twist::ConstPtr& msg)
+{
+    right_vel.data = (2 * msg->linear.x + msg->angular.z * ROBOT_BASE) / (2 * WHEEL_RAD);
+    left_vel.data = (2 * msg->linear.x + msg->angular.z * ROBOT_BASE) / (2 * WHEEL_RAD);
+}
+
+void MotorController::update()
+{
+    right_vel_pub.publish(right_vel);
+    left_vel_pub.publish(left_vel);
+}

--- a/ros_ws/src/control/src/control/motor_controller_node.cpp
+++ b/ros_ws/src/control/src/control/motor_controller_node.cpp
@@ -1,0 +1,27 @@
+/**
+ * @file motor_controller_node.cpp
+ * @brief The motor controller node source file
+ */
+
+#include <ros/ros.h>
+#include "motor_controller.h"
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, MOTOR_CONTROLLER_NODE);
+
+    MotorController mc;
+
+    ros::Rate loop_rate(LOOP_RATE);
+
+    while (ros::ok())
+    {
+        mc.update();
+        ros::spinOnce();
+        loop_rate.sleep();
+    }
+}
+
+
+
+


### PR DESCRIPTION
The motor_controller_node will convert twist messages to motor
velocities and send them to the boards which are controlling the motors.
They are currently arbitrarily scaled and will need to be adjusted later
based on the robots speed.

Closes #5
