### PR TITLE
Add rosserial nodes to launch file

### DIFF
--- a/ros_ws/src/control/launch/robot.launch
+++ b/ros_ws/src/control/launch/robot.launch
@@ -15,4 +15,8 @@
     <node pkg="control" type="teleop_mux_node" name="teleop_mux_node"/>
     <node pkg="control" type="motor_controller_node" name="motor_controller_node"/>
     
+    <!-- Arduino Stuff -->
+    <node ns="arduino_right" name="arduino_right" pkg="rosserial_python" type="serial_node.py" args="/dev/ttyACM0"/>
+    <node ns="arduino_left" name="arduino_left" pkg="rosserial_python" type="serial_node.py" args="/dev/ttyACM1"/>
+    
 </launch>


### PR DESCRIPTION
The rosserial nodes have been added to the robot.launch file.  It is
currently configured so that the right motor is /dev/ttyACM0 and the
left motor /dev/ttyACM1.

Closes #28
