### PR TITLE
Remove namespace tag from arduino

### DIFF
--- a/ros_ws/src/control/launch/robot.launch
+++ b/ros_ws/src/control/launch/robot.launch
@@ -16,7 +16,7 @@
     <node pkg="control" type="motor_controller_node" name="motor_controller_node"/>
     
     <!-- Arduino Stuff -->
-    <node ns="arduino_right" name="arduino_right" pkg="rosserial_python" type="serial_node.py" args="/dev/ttyACM0"/>
-    <node ns="arduino_left" name="arduino_left" pkg="rosserial_python" type="serial_node.py" args="/dev/ttyACM1"/>
+    <node name="arduino_right" pkg="rosserial_python" type="serial_node.py" args="/dev/ttyACM0"/>
+    <node name="arduino_left" pkg="rosserial_python" type="serial_node.py" args="/dev/ttyACM1"/>
     
 </launch>


### PR DESCRIPTION
The namespace attribute was unnecessary in the launch file for the
arduino nodes.  It has been removed and allows the arduinos to
communicate with the ros master.
