### PR TITLE
Add robot_description package

### DIFF
--- a/ros_ws/src/robot_description/CMakeLists.txt
+++ b/ros_ws/src/robot_description/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(robot_description)
+
+find_package(catkin REQUIRED COMPONENTS
+  urdf
+  xacro
+)

--- a/ros_ws/src/robot_description/package.xml
+++ b/ros_ws/src/robot_description/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<package>
+  <name>robot_description</name>
+  <version>0.0.0</version>
+  <description>The robot_description package</description>
+
+  <maintainer email="mia2n4@mst.edu">Matt Anderson</maintainer>
+
+
+  <license>BSD</license>
+
+  <url type="website">http://robotics.mst.edu</url>
+  <url type="repository">https://github.com/MST-Robotics/IGVC</url>
+
+  <author email="mia2n4@mst.edu">Matt Anderson</author> 
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>urdf</build_depend>
+  <build_depend>xacro</build_depend>
+  <run_depend>urdf</run_depend>
+  <run_depend>xacro</run_depend>
+
+</package>


### PR DESCRIPTION
The robot_description package will hold the robot model files and any
related simulator files.  It is currently empty.

Closes #47
