### PR TITLE
Add lidar launch file

### DIFF
--- a/ros_ws/src/control/launch/lidar.launch
+++ b/ros_ws/src/control/launch/lidar.launch
@@ -1,0 +1,7 @@
+<launch>
+    <node pkg="urg_node" type="urg_node" name="lidar">
+        <param name="serial_port" type="string" value="/dev/ttyACM0"/>
+        <param name="frame_id" type="string" value="laser_link"/>
+        <param name="calibrate_time" type="bool" value="true"/>
+    </node>
+</launch>


### PR DESCRIPTION
The file lidar.launch will launch urg_node which is in charge of
publishing data from the LiDAR.  It publishes in the format of a
sensor_msgs/LaserScan message
(http://docs.ros.org/api/sensor_msgs/html/msg/LaserScan.html)

There are a few paremeters defined including:
*serial_port:    /dev/ttyACM0
*frame_id:       laser_link
*calibrate_time: true

Closes #33
