### PR TITLE
Fix vision build error

### DIFF
--- a/ros_ws/src/vision/CMakeLists.txt
+++ b/ros_ws/src/vision/CMakeLists.txt
@@ -13,7 +13,6 @@ find_package(catkin REQUIRED COMPONENTS
 ## catkin specific configuration ##
 ###################################
 catkin_package(
-  INCLUDE_DIRS include
   LIBRARIES vision
   CATKIN_DEPENDS cv_bridge image_transport roscpp sensor_msgs std_msgs
   DEPENDS system_lib


### PR DESCRIPTION
The vision CMakelists.txt file was trying to import an include
directory which did not exist in the repository and so a fresh clone
or pull would result in a build failure.

Closes #68
